### PR TITLE
Document format of `license_date` field

### DIFF
--- a/src/pages/api/13-license-history.md
+++ b/src/pages/api/13-license-history.md
@@ -93,7 +93,7 @@ In the table below, fields marked with **\*** are returned by default.
 |---------------|-----------------|
 | \*nb_results| Total number of found assets in the search result. Integer. |
 | \*license| License type (`Standard`, `Standard_M`, `Extended`, `Video_HD`, `Video_4K`). String. |
-| \*license_date| Date asset was licensed. String. |
+| \*license_date| Date asset was licensed, formatted for the provided locale. This format is not intended for machine parsing and subject to change. String. |
 | \*download_url| URL to download the licensed asset (requires authentication). String. |
 | \*id| Item ID. Integer. |
 | \*title| Item title. String. |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The documentation for `license_date` doesn't mention that this field use a locale-specific format, which it should.
## Related Issue
https://git.corp.adobe.com/AdobeStock/stock-web/pull/19759

## Motivation and Context

We're working on changes that'll require upgrading [libicu](https://icu.unicode.org/), which brings minor changes in localized date formatting. From a quick review, all Stock APIs use fixed date formats that won't be affected by this, but the `license_date` is localized. Here's an example of the change:
```
current:
"4/17/25, 4:32 PM"
new:
"4/17/25, 4:32 PM"
```

If that isn't obvious, here's the hex dump:
```
current:
0000000a  34 3a 33 32 20 50 4d 22  0a                       |4:32 PM".|
new:
0000000a  34 3a 33 32 e2 80 af 50  4d 22 0a                 |4:32...PM".|
```

0xe280af is a [narrow no-break space](https://www.fileformat.info/info/unicode/char/202f/index.htm), which is nearly indistinguishable from a normal space. From some discussion internally, we aren't aware of any clients parsing this field, but it's possible. 
## How Has This Been Tested?

From some testing, locale-aware date parsing functions like PHP's `IntlDateFormatter->parse()` and JS's `Date.Parse()` handle both formats properly properly:
```
$ php -r  '$old = "4/17/25, 4:32 PM"; $new = "4/17/25, 4:32 PM"; $fmt = new IntlDateFormatter("en_US", IntlDateFormatter::SHORT, IntlDateFormatter::SHORT); var_dump(phpversion(), $fmt->parse($old), $fmt->parse($new));'
string(6) "8.3.15"
int(1744907520)
int(1744907520)

$ node -e 'const oldDate = "4/17/25, 4:32 PM", newDate = "4/17/25, 4:32 PM"; console.log(Date.parse(oldDate), Date.parse(newDate));'
1744932720000 1744932720000
```

Therefore, if API clients are using one of those functions, they're probably safe for now. However, there's no guarantee those will keep working. Of course, ad-hoc parsing (e.g. regexs) is more likely to break.

## Screenshots (if appropriate):
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
